### PR TITLE
Remove forbidden characters in filesystem

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,12 +124,17 @@ for (let i = 0; i < lessons.length; i++) {
         continue
     }
 
+    // \ / : * ? " < > | are not allowed in windows file name
+    const safePath = title => title.replace(/[\\/:*?"<>|]/g, '')
 
     const
         lessonName = lessons[j],
-        fileName = `${episode.index + 1}. ${episode.title}.${EXTENSION}`,
-        path = join(DOWNLOAD_DIR, course.title, lessonName),
-        tempDir = join(path, '.tmp', episode.title),
+        safeLessonName = safePath(lessonName),
+        safeCourseTitle = safePath(course.title),
+        safeEpisodeTitle = safePath(episode.title),
+        fileName = `${episode.index + 1}. ${safeEpisodeTitle}.${EXTENSION}`,
+        path = join(DOWNLOAD_DIR, safeCourseTitle, safeLessonName),
+        tempDir = join(path, '.tmp', safeEpisodeTitle),
         filePath = join(tempDir, fileName),
         decryptionKeyPath = join(tempDir, 'key.bin'),
         captionPath = join(tempDir, `caption.${CAPTION_EXT}`),

--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ for (let i = 0; i < lessons.length; i++) {
     }
 
     // \ / : * ? " < > | are not allowed in windows file name
-    const safePath = title => title.replace(/[\\/:*?"<>|]/g, '')
+    const safePath = title => title.replace(/[\/\\:*?"<>|]/g, '')
 
     const
         lessonName = lessons[j],


### PR DESCRIPTION
Found an error in the Windows file system. It fails when it tries to make a file or folder with one of the forbidden characters. A course or episode with a colon, [for example](https://frontendmasters.com/courses/algorithms/path-finding-base-case/) would fail during the mkdir process. Here's a full list of forbidden characters from the prompt:    \ / : * ? " < > |