### PR TITLE
Fix for issue #14 - Not able to download 1080p on some videos

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -8,7 +8,7 @@ export const CAPTION_EXT = 'vtt'
 export const QUALITY_FORMAT = {
     2160: 'index_2160p_Q10_20mbps',
     1440: 'index_1440p_Q10_9mbps',
-    1080: 'index_1080_Q10_7mbps',
+    1080: 'index_1080_Q8_7mbps',
     720: 'index_720_Q8_5mbps',
     360: 'index_360_Q8_2mbps'
 }


### PR DESCRIPTION
Attempt to fix issue #14

Looks like Frontend Masters have different names for their 1080p versions.

Looking at: https://frontendmasters.com/courses/web3-smart-contracts/introduction/

![image](https://user-images.githubusercontent.com/10554515/223533614-29cc7380-7843-4c1b-904f-ce7bdaf009c5.png)

There is not "Q10" in their 1080p format.

However, this seems to vary for some newer videos such as: https://frontendmasters.com/courses/web-auth-apis/introduction/

![image](https://user-images.githubusercontent.com/10554515/223533897-d7816e68-51c3-4a4a-bb0d-c00c4f91aa17.png)

In the newer videos, they do use "Q10" for their 1080p format.

**Note**: an ideal fix should be doing a fussy match in the "qualities" check loop here: https://github.com/abdulrahman1s/fem-dl/blob/master/src/index.js#L149 multiple versions of the 1080p string. Unfortunately, at this moment I am traveling so I don't have my PC to test such changes and create a PR.


