### PR TITLE
Feat: Allow user to select lessons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSE",
       "dependencies": {
         "@dropb/ffmpeg-progress": "^2.0.0",
+        "enquirer": "^2.4.1",
         "fetch-cookie": "^2.1.0",
         "fetch-retry": "^5.0.3",
         "ffmpeg-static": "^5.1.0",
@@ -61,6 +62,14 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -227,6 +236,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/enquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/enquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/env-paths": {
@@ -613,9 +653,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -699,6 +739,11 @@
       "requires": {
         "debug": "4"
       }
+    },
+    "ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
     },
     "ansi-regex": {
       "version": "6.0.1",
@@ -792,6 +837,30 @@
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "requires": {
         "clone": "^1.0.2"
+      }
+    },
+    "enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "requires": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "env-paths": {
@@ -1043,9 +1112,9 @@
       }
     },
     "tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "UNLICENSE",
       "dependencies": {
         "@dropb/ffmpeg-progress": "^2.0.0",
-        "enquirer": "^2.4.1",
         "fetch-cookie": "^2.1.0",
         "fetch-retry": "^5.0.3",
         "ffmpeg-static": "^5.1.0",
@@ -62,14 +61,6 @@
       },
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -236,37 +227,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/enquirer/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/enquirer/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/env-paths": {
@@ -740,11 +700,6 @@
         "debug": "4"
       }
     },
-    "ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
-    },
     "ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -837,30 +792,6 @@
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "requires": {
         "clone": "^1.0.2"
-      }
-    },
-    "enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "requires": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
       }
     },
     "env-paths": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "type": "module",
   "dependencies": {
     "@dropb/ffmpeg-progress": "^2.0.0",
+    "enquirer": "^2.4.1",
     "fetch-cookie": "^2.1.0",
     "fetch-retry": "^5.0.3",
     "ffmpeg-static": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "type": "module",
   "dependencies": {
     "@dropb/ffmpeg-progress": "^2.0.0",
-    "enquirer": "^2.4.1",
     "fetch-cookie": "^2.1.0",
     "fetch-retry": "^5.0.3",
     "ffmpeg-static": "^5.1.0",

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -67,3 +67,13 @@ export function safeJoin(...path) {
 
 
 export { setTimeout as sleep } from 'node:timers/promises'
+
+/**
+ * Create element to index mapping
+ * @param {string[]} arr Array of strings
+ * @returns {object}
+ */
+export const getIndexMapping = (arr = []) => arr.reduce((acc, curr, index) => {
+	acc[curr] = index;
+	return acc;
+}, {});

--- a/src/util/prompt.js
+++ b/src/util/prompt.js
@@ -1,0 +1,22 @@
+import enquirer from 'enquirer';
+
+const { MultiSelect } = enquirer;
+
+/**
+ * Ask user to select multiple lessons to download
+ * @param {string[]} lessonNames
+ * @returns {Promise<string[]>}
+ */
+export const selectLessonsPrompt = async (lessonNames = []) => {
+    const prompt = new MultiSelect({
+        name: 'selectedLessons',
+        message: 'Select the lesson(s) to download',
+        choices: lessonNames.map(lessonName => ({
+            name: lessonName,
+            value: lessonName,
+        })),
+        onCancel: () => process.nextTick(() => process.exit(0))
+    });
+    const selectedLessons = await prompt.run();
+    return selectedLessons;
+};

--- a/src/util/prompt.js
+++ b/src/util/prompt.js
@@ -1,6 +1,66 @@
-import enquirer from 'enquirer';
+import prompts from 'prompts';
+import os from 'node:os';
+import { FEM_COURSE_REG, SUPPORTED_FORMATS, QUALITY_FORMAT } from '../constants.js';
+import { safeJoin, isPathExists } from './common.js';
 
-const { MultiSelect } = enquirer;
+const env = process.env;
+const exitOnCancel = state => {
+    if (state.aborted) process.nextTick(() => process.exit(0))
+};
+
+export const defaultPrompts = () => {
+    return prompts([{
+        type: 'text',
+        name: 'COURSE_SLUG',
+        message: 'The url of the course you want to download',
+        initial: env['FEM_DL_COURSE_URL'] || 'https://frontendmasters.com/courses/...',
+        validate: v => !v.endsWith('...') && FEM_COURSE_REG.test(v),
+        format: v => v.match(FEM_COURSE_REG)[2],
+        onState: exitOnCancel
+    }, {
+        type: 'password',
+        name: 'TOKEN',
+        message: 'Paste the value of "fem_auth_mod" cookie (visit: https://frontendmasters.com)',
+        format: v => decodeURIComponent(v) === v ? encodeURIComponent(v) : v,
+        initial: env['FEM_DL_COOKIES'],
+        onState: exitOnCancel
+    }, {
+        type: 'select',
+        name: 'PREFERRED_QUALITY',
+        message: 'Which stream quality do you prefer?',
+        choices: [2160, 1440, 1080, 720, 360].map((value) => ({ title: value + 'p', value })),
+        format: v => QUALITY_FORMAT[v],
+        onState: exitOnCancel
+    }, {
+        type: 'select',
+        message: 'Which video format you prefer?',
+        name: 'EXTENSION',
+        initial: 1,
+        choices: SUPPORTED_FORMATS.map((value) => ({ title: value, value })),
+        onState: exitOnCancel
+    }, {
+        type: 'confirm',
+        initial: true,
+        name: 'INCLUDE_CAPTION',
+        message: 'Include episode caption?',
+        onState: exitOnCancel
+    },
+    {
+        type: 'confirm',
+        initial: false,
+        name: 'DOWNLOAD_SPECIFIC_LESSON',
+        message: 'Do you want to download specific lesson(s)?',
+        onState: exitOnCancel
+    },
+    {
+        type: 'text',
+        message: 'Download directory path',
+        name: 'DOWNLOAD_DIR',
+        initial: env['FEM_DL_DOWNLOAD_PATH'] || safeJoin(os.homedir(), 'Downloads'),
+        validate: v => isPathExists(v),
+        onState: exitOnCancel
+    }]);
+}
 
 /**
  * Ask user to select multiple lessons to download
@@ -8,15 +68,18 @@ const { MultiSelect } = enquirer;
  * @returns {Promise<string[]>}
  */
 export const selectLessonsPrompt = async (lessonNames = []) => {
-    const prompt = new MultiSelect({
+    const { selectedLessons } =     await prompts([{
+        type: 'multiselect',
         name: 'selectedLessons',
+        hint: '- Press Space to select or unselect. Return to submit',
         message: 'Select the lesson(s) to download',
         choices: lessonNames.map(lessonName => ({
-            name: lessonName,
+            title: lessonName,
             value: lessonName,
         })),
-        onCancel: () => process.nextTick(() => process.exit(0))
-    });
-    const selectedLessons = await prompt.run();
+        onState: exitOnCancel,
+        instructions: false,
+        optionsPerPage: 20,
+    }]);
     return selectedLessons;
 };


### PR DESCRIPTION
The script currently allows us to download the entire course. However, there may be times when the download fails due to a network issue or rate limiting. In this case, we may not want to download the lessons that have already been downloaded. Instead, we can select the lessons that were not downloaded or were only partially downloaded.

I have added a feature to ask the user if they want to download specific lessons. If so, the script will prompt the user with a list of all the lessons (not episodes) so that they can select the ones they want to download.